### PR TITLE
Set $GOBIN to current bin folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ allpackages = $(if $(__allpackages),,$(eval __allpackages := $$(_allpackages)))$
 
 export GOPATH := $(CURDIR)/.GOPATH
 
+export GOBIN := $(CURDIR)/bin
+
 Q := $(if $V,,@)
 
 .GOPATH/.ok:


### PR DESCRIPTION
By setting GOBIN users can have a system wide location for installing "go get" based executable, e.g. glide, but having it makes this makefile install to GOBIN, so this change makes sure that GOBIN is set to the correct location when building from make.

Users will still be able to use go installed executables as long as they have added GOBIN to their path before running make

fixes #9 