### PR TITLE
Switch from gvt to dep (#17)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,12 @@ setup: clean .GOPATH/.ok
 	    echo "/.GOPATH" >> .gitignore; \
 	    echo "/bin" >> .gitignore; \
 	fi
-	go get -u github.com/FiloSottile/gvt
-	- ./bin/gvt fetch golang.org/x/tools/cmd/goimports
-	- ./bin/gvt fetch github.com/wadey/gocovmerge
+	go get -u github.com/golang/dep/cmd/dep
+	- go get -u golang.org/x/tools/cmd/goimports
+	- go get -u github.com/wadey/gocovmerge
+	@test -f Gopkg.toml || \
+		(cd $(CURDIR)/.GOPATH/src/$(IMPORT_PATH) && ./bin/dep init)
+	(cd $(CURDIR)/.GOPATH/src/$(IMPORT_PATH) && ./bin/dep ensure)
 
 VERSION          := $(shell git describe --tags --always --dirty="-dev")
 DATE             := $(shell date -u '+%Y-%m-%d-%H%M UTC')


### PR DESCRIPTION
Since [dep](https://github.com/golang/dep) is now considered ready for production.