### PR TITLE
Remove need for gvt, also dont pollute vendor dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,8 @@ setup: clean .GOPATH/.ok
 	    echo "/.GOPATH" >> .gitignore; \
 	    echo "/bin" >> .gitignore; \
 	fi
-	go get -u github.com/FiloSottile/gvt
-	- ./bin/gvt fetch golang.org/x/tools/cmd/goimports
-	- ./bin/gvt fetch github.com/wadey/gocovmerge
+	go get -u golang.org/x/tools/cmd/goimports
+	go get -u github.com/wadey/gocovmerge
 
 VERSION          := $(shell git describe --tags --always --dirty="-dev")
 DATE             := $(shell date -u '+%Y-%m-%d-%H%M UTC')


### PR DESCRIPTION
gvt pollutes the vendor folder with the source files for goimports and gocovmerge, go get will just pull the executable into bin. It also means there is no dependency on gvt